### PR TITLE
Add support for React keys via a uniqueKey prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,21 @@ Using `react-secure-link` for outbound links prevents the new tab from having ac
 
 ### API
 
-The `SecureLink` component has the following props:
+In addition to any prop defined as part of the `React.HTMLAttributes<HTMLAnchorElement>` interface (i.e. `className`, `id`, `role`, `style`), the `SecureLink` component has the following custom props:
 
 | prop        | Required | Type     | Description                                                              |
 |-------------|----------|----------|--------------------------------------------------------------------------|
 | `url`       | Yes      | `string` | The URL to navigate to.                                                  |
 | `text`      | No       | `string` | The text to show.  If not provided, the given URL will be shown instead. |
-| `className` | No       | `string` | The CSS class to apply to the link.                                      |
-| `style`     | No       | `object` | The CSS styling to apply to the link.                                    |
+| `uniqueKey` | No       | `string` or `number` | A unique key to identify the link.  This is being used as a `key` value for the component.  For more information, refer to [React's website about keys](https://reactjs.org/docs/lists-and-keys.html#keys). |
 
+### Basic Usage Example
 
-### Full Usage Example
+```tsx
+<SecureLink url="https://www.npmjs.com/package/react-secure-link" />
+```
+
+### Advance Usage Example
 
 ```tsx
 <SecureLink
@@ -51,5 +55,6 @@ The `SecureLink` component has the following props:
     text="react-secure-link on NPM"
     className="no-link-decoration"
     style={{ color: "red" }}
+    uniqueKey={123}
 />
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-secure-link",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.12.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-secure-link",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A TypeScript compatible React component to avoid security exploits when opening a link in a new tab.",
   "keywords": [
     "react",

--- a/src/components/__tests__/secure-link.test.tsx
+++ b/src/components/__tests__/secure-link.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import React, { CSSProperties } from "react";
+import React, { Key } from "react";
 import { render, screen } from "@testing-library/react";
 
 import { SecureLink } from "../secure-link";
@@ -19,84 +19,75 @@ const emptyTextValues = [
     "",
 ];
 
-const classNamePropValues = [
+const uniqueKeyPropValues = [
     undefined,
     null,
-    "",
-    faker.lorem.word(),
+    faker.random.number(),
+    faker.random.word(),
 ];
 
-const stylePropValues = [
-    undefined,
-    null,
-    {},
-    { color: "red" },
-];
-
-function renderSecureLink(text: string, className: string, style: CSSProperties): void {
-    render(<SecureLink text={text} url={url} className={className} style={style} />);
+function renderSecureLink(text: string, uniqueKey: Key): void {
+    render(<SecureLink text={text} url={url} key={uniqueKey} />);
 }
 
 function getLinkByRole(): HTMLAnchorElement {
     return screen.getByRole("link") as HTMLAnchorElement;
 }
 
-function itRendersWithoutCrashing(text: string, className: string, style: CSSProperties): void {
+function itRendersWithoutCrashing(text: string, uniqueKey: Key): void {
     it("renders link without crashing", () => {
-        renderSecureLink(text, className, style);
+        renderSecureLink(text, uniqueKey);
 
         expect(getLinkByRole()).toBeInTheDocument();
     });
 }
 
-function itHasExpectedAttributes(text: string, className: string, style: CSSProperties): void {
+function itHasExpectedAttributes(text: string, uniqueKey: Key): void {
     it("links to given URL", () => {
-        renderSecureLink(text, className, style);
+        renderSecureLink(text, uniqueKey);
 
         expect(getLinkByRole()).toHaveAttribute("href", url);
     });
 
     it("has expected attributes to open link securely", () => {
-        renderSecureLink(text, className, style);
+        renderSecureLink(text, uniqueKey);
 
         expect(getLinkByRole()).toHaveAttribute("rel", "noopener noreferrer");
     });
 
     it("has expected attributes to open link in new tab", () => {
-        renderSecureLink(text, className, style);
+        renderSecureLink(text, uniqueKey);
 
         expect(getLinkByRole()).toHaveAttribute("target", "_blank");
     });
 }
 
-each(classNamePropValues).describe(`when given className="%s"`, (className?) => {
-    each(stylePropValues).describe(`when given style="%s"`, (style?) => {
-        each(emptyTextValues).describe(`when given empty text="%s"`, (text?) => {
-            itRendersWithoutCrashing(text, className, style);
-            itHasExpectedAttributes(text, className, style);
+each(uniqueKeyPropValues).describe(`when given uniqueKey="%s"`, (uniqueKey?) => {
+    each(emptyTextValues).describe(`when given empty text="%s"`, (text?) => {
+        itRendersWithoutCrashing(text, uniqueKey);
+        itHasExpectedAttributes(text, uniqueKey);
 
-            it("text is the same as the URL", () => {
-                renderSecureLink(text, className, style);
+        it("text is the same as the URL", () => {
+            renderSecureLink(text, uniqueKey);
 
-                expect(getLinkByRole()).toHaveTextContent(url);
-            });
+            expect(getLinkByRole()).toHaveTextContent(url);
+        });
+    });
+
+    describe("when given text", () => {
+        let text: string;
+
+        beforeAll(() => {
+            text = faker.lorem.word();
         });
 
-        describe("when given text", () => {
-            let text: string;
+        itRendersWithoutCrashing(text, uniqueKey);
+        itHasExpectedAttributes(text, uniqueKey);
 
-            beforeAll(() => {
-                text = faker.lorem.word();
-            });
+        it("has given text", () => {
+            renderSecureLink(text, uniqueKey);
 
-            itRendersWithoutCrashing(text, className, style);
-            itHasExpectedAttributes(text, className, style);
-
-            it("has given text", () => {
-                renderSecureLink(text, className, style);
-
-                expect(getLinkByRole()).toHaveTextContent(text);
-            });
+            expect(getLinkByRole()).toHaveTextContent(text);
         });
     });
 });

--- a/src/components/secure-link.tsx
+++ b/src/components/secure-link.tsx
@@ -1,20 +1,18 @@
-import React, { CSSProperties, ReactElement } from "react";
+import React, { Key, ReactElement } from "react";
 
-interface SecureLinkProps {
+interface SecureLinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
     url: string;
     text?: string;
-    className?: string;
-    style?: CSSProperties;
+    uniqueKey?: Key;
 }
 
-export function SecureLink({ url, text, className, style }: SecureLinkProps): ReactElement {
+export function SecureLink({ url, text, uniqueKey }: SecureLinkProps): ReactElement {
     return (
         <a
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className={className}
-            style={style}
+            key={uniqueKey}
         >
             {
                 text ? text : url


### PR DESCRIPTION
It's not possible to create a prop named `key` without getting errors, and I didn't want to pass arbitrary props into the component, so I named the prop`uniqueKey`.

This also vastly simplifies how common props can be passed into `SecureLink` by extending the `React.HTMLAttributes<HTMLAnchorElement>` interface which has the props (in addition to many others), that I was manually defining (`className` and `style`).